### PR TITLE
Secretbox and secretbox_open

### DIFF
--- a/lib/sodium.js
+++ b/lib/sodium.js
@@ -65,10 +65,22 @@
       return this.lib.c.crypto_box(plaintext, nonce, pubkey, this.secretKey).slice(16);
     };
 
+    Sodium.prototype.secretbox = function(_arg) {
+      var nonce, plaintext;
+      plaintext = _arg.plaintext, nonce = _arg.nonce;
+      return this.lib.c.crypto_secretbox(plaintext, nonce, this.secretKey).slice(16);
+    };
+
     Sodium.prototype.decrypt = function(_arg) {
       var ciphertext, nonce, pubkey;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce, pubkey = _arg.pubkey;
       return this.lib.c.crypto_box_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, pubkey, this.secretKey);
+    };
+
+    Sodium.prototype.secretbox_open = function(_arg) {
+      var ciphertext, nonce;
+      ciphertext = _arg.ciphertext, nonce = _arg.nonce;
+      return this.lib.c.crypto_secretbox_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, this.secretKey);
     };
 
     return Sodium;

--- a/lib/tweetnacl.js
+++ b/lib/tweetnacl.js
@@ -54,10 +54,22 @@
       return u2b(this.lib.js.box(plaintext, nonce, pubkey, this.secretKey));
     };
 
+    TweetNaCl.prototype.secretbox = function(_arg) {
+      var nonce, plaintext;
+      plaintext = _arg.plaintext, nonce = _arg.nonce;
+      return u2b(this.lib.js.secretbox(plaintext, nonce, this.secretKey));
+    };
+
     TweetNaCl.prototype.decrypt = function(_arg) {
       var ciphertext, nonce, pubkey;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce, pubkey = _arg.pubkey;
       return u2b(this.lib.js.box.open(b2u(ciphertext), nonce, pubkey, this.secretKey));
+    };
+
+    TweetNaCl.prototype.secretbox_open = function(_arg) {
+      var ciphertext, nonce;
+      ciphertext = _arg.ciphertext, nonce = _arg.nonce;
+      return u2b(this.lib.js.secretbox.open(b2u(ciphertext), nonce, this.secretKey));
     };
 
     return TweetNaCl;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keybase-nacl",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A small wrapper library to switch between C and JS NaCl depending on the install",
   "main": "lib/main.js",
   "scripts": {

--- a/src/sodium.iced
+++ b/src/sodium.iced
@@ -58,6 +58,7 @@ exports.Sodium = class Sodium extends Base
   sign : ({detached, payload}) ->
     sig = @lib.c.crypto_sign payload, @secretKey
     if detached then @_detach(sig).sig else sig
+
   #
   # @method encrypt
   # Encrypt a given plaintext
@@ -69,13 +70,31 @@ exports.Sodium = class Sodium extends Base
     return @lib.c.crypto_box(plaintext, nonce, pubkey, @secretKey)[16...]
 
   #
+  # @method secretbox
+  # Secretbox a given plaintext
+  # @param {Buffer} plaintext The plaintext to encrypt
+  # @param {Buffer} nonce The nonce
+  # @return {Buffer} The encrypted plaintext
+  secretbox : ({plaintext, nonce}) ->
+    return @lib.c.crypto_secretbox(plaintext, nonce, @secretKey)[16...]
+
+  #
   # @method decrypt
   # 
   # @param {Buffer} ciphertext The ciphertext to decrypt
   # @param {Buffer} nonce The nonce 
   # @param {Buffer} pubkey The public key that was used for encryption
-  # @return {Buffer} The decrypted plaintext
+  # @return {Buffer} The decrypted ciphertext
   decrypt : ({ciphertext, nonce, pubkey}) ->
     return @lib.c.crypto_box_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, pubkey, @secretKey)
+
+  #
+  # @method secretbox_open
+  # Decrypt a given secretbox
+  # @param {Buffer} ciphertext The ciphertext to decrypt
+  # @param {Buffer} nonce The nonce
+  # @return {Buffer} The decrypted ciphertext
+  secretbox_open : ({ciphertext, nonce}) ->
+    return @lib.c.crypto_secretbox_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, @secretKey)
 
 #================================================================

--- a/src/tweetnacl.iced
+++ b/src/tweetnacl.iced
@@ -66,13 +66,31 @@ exports.TweetNaCl = class TweetNaCl extends Base
     return u2b(@lib.js.box(plaintext, nonce, pubkey, @secretKey))
 
   #
+  # @method secretbox
+  # Secretbox a given plaintext
+  # @param {Buffer} plaintext The plaintext to encrypt
+  # @param {Buffer} nonce The nonce
+  # @return {Buffer} The encrypted plaintext
+  secretbox : ({plaintext, nonce}) ->
+    return u2b(@lib.js.secretbox(plaintext, nonce, @secretKey))
+
+  #
   # @method decrypt
   # 
   # @param {Buffer} ciphertext The ciphertext to decrypt
   # @param {Buffer} nonce The nonce 
   # @param {Buffer} pubkey The public key that was used for encryption
-  # @return {Buffer} The decrypted plaintext
+  # @return {Buffer} The decrypted ciphertext
   decrypt : ({ciphertext, nonce, pubkey}) ->
     return u2b(@lib.js.box.open(b2u(ciphertext), nonce, pubkey, @secretKey))
+
+  #
+  # @method secretbox_open
+  # Decrypt a given secretbox
+  # @param {Buffer} ciphertext The ciphertext to decrypt
+  # @param {Buffer} nonce The nonce
+  # @return {Buffer} The decrypted ciphertext
+  secretbox_open : ({ciphertext, nonce}) ->
+    return u2b(@lib.js.secretbox.open(b2u(ciphertext), nonce, @secretKey))
 
 #================================================================

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -171,10 +171,22 @@
       return this.lib.c.crypto_box(plaintext, nonce, pubkey, this.secretKey).slice(16);
     };
 
+    Sodium.prototype.secretbox = function(_arg) {
+      var nonce, plaintext;
+      plaintext = _arg.plaintext, nonce = _arg.nonce;
+      return this.lib.c.crypto_secretbox(plaintext, nonce, this.secretKey).slice(16);
+    };
+
     Sodium.prototype.decrypt = function(_arg) {
       var ciphertext, nonce, pubkey;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce, pubkey = _arg.pubkey;
       return this.lib.c.crypto_box_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, pubkey, this.secretKey);
+    };
+
+    Sodium.prototype.secretbox_open = function(_arg) {
+      var ciphertext, nonce;
+      ciphertext = _arg.ciphertext, nonce = _arg.nonce;
+      return this.lib.c.crypto_secretbox_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, this.secretKey);
     };
 
     return Sodium;
@@ -242,10 +254,22 @@
       return u2b(this.lib.js.box(plaintext, nonce, pubkey, this.secretKey));
     };
 
+    TweetNaCl.prototype.secretbox = function(_arg) {
+      var nonce, plaintext;
+      plaintext = _arg.plaintext, nonce = _arg.nonce;
+      return u2b(this.lib.js.secretbox(plaintext, nonce, this.secretKey));
+    };
+
     TweetNaCl.prototype.decrypt = function(_arg) {
       var ciphertext, nonce, pubkey;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce, pubkey = _arg.pubkey;
       return u2b(this.lib.js.box.open(b2u(ciphertext), nonce, pubkey, this.secretKey));
+    };
+
+    TweetNaCl.prototype.secretbox_open = function(_arg) {
+      var ciphertext, nonce;
+      ciphertext = _arg.ciphertext, nonce = _arg.nonce;
+      return u2b(this.lib.js.secretbox.open(b2u(ciphertext), nonce, this.secretKey));
     };
 
     return TweetNaCl;


### PR DESCRIPTION
Welp, I attempted to rebase but I had already pushed what I wanted to rebase. Oh well. This simply adds & tests wrappers for `secretbox` and `secretbox_open` - implementation is almost identical to their asymmetric counterparts.