### PR TITLE
Completed beforenm and open_afternm wrappers

### DIFF
--- a/lib/sodium.js
+++ b/lib/sodium.js
@@ -24,6 +24,14 @@
       };
     };
 
+    Sodium.prototype._pad = function(x) {
+      return Buffer.concat([Buffer.alloc(16), x]);
+    };
+
+    Sodium.prototype._unpad = function(x) {
+      return x.slice(16);
+    };
+
     Sodium.prototype.verify = function(_arg) {
       var detached, err, msg, payload, r_payload, sig;
       payload = _arg.payload, sig = _arg.sig, detached = _arg.detached;
@@ -62,25 +70,25 @@
     Sodium.prototype.encrypt = function(_arg) {
       var nonce, plaintext, pubkey;
       plaintext = _arg.plaintext, nonce = _arg.nonce, pubkey = _arg.pubkey;
-      return this.lib.c.crypto_box(plaintext, nonce, pubkey, this.secretKey).slice(16);
+      return this._unpad(this.lib.c.crypto_box(plaintext, nonce, pubkey, this.secretKey));
     };
 
     Sodium.prototype.secretbox = function(_arg) {
       var nonce, plaintext;
       plaintext = _arg.plaintext, nonce = _arg.nonce;
-      return this.lib.c.crypto_secretbox(plaintext, nonce, this.secretKey).slice(16);
+      return this._unpad(this.lib.c.crypto_secretbox(plaintext, nonce, this.secretKey));
     };
 
     Sodium.prototype.decrypt = function(_arg) {
       var ciphertext, nonce, pubkey;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce, pubkey = _arg.pubkey;
-      return this.lib.c.crypto_box_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, pubkey, this.secretKey);
+      return this.lib.c.crypto_box_open(this._pad(ciphertext), nonce, pubkey, this.secretKey);
     };
 
     Sodium.prototype.secretbox_open = function(_arg) {
       var ciphertext, nonce;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce;
-      return this.lib.c.crypto_secretbox_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, this.secretKey);
+      return this.lib.c.crypto_secretbox_open(this._pad(ciphertext), nonce, this.secretKey);
     };
 
     Sodium.prototype.box_beforenm = function(_arg) {
@@ -92,7 +100,7 @@
     Sodium.prototype.box_open_afternm = function(_arg) {
       var ciphertext, nonce, secret;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce, secret = _arg.secret;
-      return this.lib.c.crypto_box_open_afternm(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, secret);
+      return this.lib.c.crypto_box_open_afternm(this._pad(ciphertext), nonce, secret);
     };
 
     return Sodium;

--- a/lib/sodium.js
+++ b/lib/sodium.js
@@ -83,6 +83,18 @@
       return this.lib.c.crypto_secretbox_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, this.secretKey);
     };
 
+    Sodium.prototype.box_beforenm = function(_arg) {
+      var pubkey, seckey;
+      pubkey = _arg.pubkey, seckey = _arg.seckey;
+      return this.lib.c.crypto_box_beforenm(pubkey, seckey);
+    };
+
+    Sodium.prototype.box_open_afternm = function(_arg) {
+      var ciphertext, nonce, secret;
+      ciphertext = _arg.ciphertext, nonce = _arg.nonce, secret = _arg.secret;
+      return this.lib.c.crypto_box_open_afternm(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, secret);
+    };
+
     return Sodium;
 
   })(Base);

--- a/lib/tweetnacl.js
+++ b/lib/tweetnacl.js
@@ -72,6 +72,18 @@
       return u2b(this.lib.js.secretbox.open(b2u(ciphertext), nonce, this.secretKey));
     };
 
+    TweetNaCl.prototype.box_beforenm = function(_arg) {
+      var pubkey, seckey;
+      pubkey = _arg.pubkey, seckey = _arg.seckey;
+      return u2b(this.lib.js.box.before(pubkey, seckey));
+    };
+
+    TweetNaCl.prototype.box_open_afternm = function(_arg) {
+      var ciphertext, nonce, secret;
+      ciphertext = _arg.ciphertext, nonce = _arg.nonce, secret = _arg.secret;
+      return u2b(this.lib.js.box.open.after(b2u(ciphertext), nonce, secret));
+    };
+
     return TweetNaCl;
 
   })(Base);

--- a/src/sodium.iced
+++ b/src/sodium.iced
@@ -97,4 +97,23 @@ exports.Sodium = class Sodium extends Base
   secretbox_open : ({ciphertext, nonce}) ->
     return @lib.c.crypto_secretbox_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, @secretKey)
 
+  #
+  # @method box_beforenm
+  # Precopmute a shared secret
+  # @param {Buffer} pubkey The public key to precompute with
+  # @param {Buffer} seckey The secret key to precompute with
+  # @return {Buffer} The precomputed shared secret key
+  box_beforenm : ({pubkey, seckey}) ->
+    return @lib.c.crypto_box_beforenm(pubkey, seckey)
+
+  #
+  # @method box_open_afternm
+  # Precopmute a shared secret
+  # @param {Buffer} ciphertext The ciphertext to decrypt
+  # @param {Buffer} nonce The nonce
+  # @param {Buffer} secret The precomputed secret
+  # @return {Buffer} The decrypted ciphertext
+  box_open_afternm : ({ciphertext, nonce, secret}) ->
+    return @lib.c.crypto_box_open_afternm(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, secret)
+
 #================================================================

--- a/src/sodium.iced
+++ b/src/sodium.iced
@@ -16,6 +16,9 @@ exports.Sodium = class Sodium extends Base
     l = @lib.c.crypto_sign_BYTES
     { sig: sig[0...l], payload : sig[l...] }
 
+  _pad : (x) -> Buffer.concat([Buffer.alloc(16), x])
+  _unpad : (x) -> x[16...]
+
   #------
   
   #
@@ -67,7 +70,7 @@ exports.Sodium = class Sodium extends Base
   # @param {Buffer} pubkey The public key to encrypt for
   # @return {Buffer} The encrypted plaintext
   encrypt : ({plaintext, nonce, pubkey}) ->
-    return @lib.c.crypto_box(plaintext, nonce, pubkey, @secretKey)[16...]
+    return @_unpad(@lib.c.crypto_box(plaintext, nonce, pubkey, @secretKey))
 
   #
   # @method secretbox
@@ -76,7 +79,7 @@ exports.Sodium = class Sodium extends Base
   # @param {Buffer} nonce The nonce
   # @return {Buffer} The encrypted plaintext
   secretbox : ({plaintext, nonce}) ->
-    return @lib.c.crypto_secretbox(plaintext, nonce, @secretKey)[16...]
+    return @_unpad(@lib.c.crypto_secretbox(plaintext, nonce, @secretKey))
 
   #
   # @method decrypt
@@ -86,7 +89,7 @@ exports.Sodium = class Sodium extends Base
   # @param {Buffer} pubkey The public key that was used for encryption
   # @return {Buffer} The decrypted ciphertext
   decrypt : ({ciphertext, nonce, pubkey}) ->
-    return @lib.c.crypto_box_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, pubkey, @secretKey)
+    return @lib.c.crypto_box_open(@_pad(ciphertext), nonce, pubkey, @secretKey)
 
   #
   # @method secretbox_open
@@ -95,7 +98,7 @@ exports.Sodium = class Sodium extends Base
   # @param {Buffer} nonce The nonce
   # @return {Buffer} The decrypted ciphertext
   secretbox_open : ({ciphertext, nonce}) ->
-    return @lib.c.crypto_secretbox_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, @secretKey)
+    return @lib.c.crypto_secretbox_open(@_pad(ciphertext), nonce, @secretKey)
 
   #
   # @method box_beforenm
@@ -114,6 +117,6 @@ exports.Sodium = class Sodium extends Base
   # @param {Buffer} secret The precomputed secret
   # @return {Buffer} The decrypted ciphertext
   box_open_afternm : ({ciphertext, nonce, secret}) ->
-    return @lib.c.crypto_box_open_afternm(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, secret)
+    return @lib.c.crypto_box_open_afternm(@_pad(ciphertext), nonce, secret)
 
 #================================================================

--- a/src/tweetnacl.iced
+++ b/src/tweetnacl.iced
@@ -93,4 +93,23 @@ exports.TweetNaCl = class TweetNaCl extends Base
   secretbox_open : ({ciphertext, nonce}) ->
     return u2b(@lib.js.secretbox.open(b2u(ciphertext), nonce, @secretKey))
 
+  #
+  # @method box_beforenm
+  # Precopmute a shared secret
+  # @param {Buffer} pubkey The public key to precompute with
+  # @param {Buffer} seckey The secret key to precompute with
+  # @return {Buffer} The precomputed shared secret key
+  box_beforenm : ({pubkey, seckey}) ->
+    return u2b(@lib.js.box.before(pubkey, seckey))
+
+  #
+  # @method box_open_afternm
+  # Precopmute a shared secret
+  # @param {Buffer} ciphertext The ciphertext to decrypt
+  # @param {Buffer} nonce The nonce
+  # @param {Buffer} secret The precomputed secret
+  # @return {Buffer} The decrypted ciphertext
+  box_open_afternm : ({ciphertext, nonce, secret}) ->
+    return u2b(@lib.js.box.open.after(b2u(ciphertext), nonce, secret))
+
 #================================================================

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -130,6 +130,14 @@
       };
     };
 
+    Sodium.prototype._pad = function(x) {
+      return Buffer.concat([Buffer.alloc(16), x]);
+    };
+
+    Sodium.prototype._unpad = function(x) {
+      return x.slice(16);
+    };
+
     Sodium.prototype.verify = function(_arg) {
       var detached, err, msg, payload, r_payload, sig;
       payload = _arg.payload, sig = _arg.sig, detached = _arg.detached;
@@ -168,25 +176,25 @@
     Sodium.prototype.encrypt = function(_arg) {
       var nonce, plaintext, pubkey;
       plaintext = _arg.plaintext, nonce = _arg.nonce, pubkey = _arg.pubkey;
-      return this.lib.c.crypto_box(plaintext, nonce, pubkey, this.secretKey).slice(16);
+      return this._unpad(this.lib.c.crypto_box(plaintext, nonce, pubkey, this.secretKey));
     };
 
     Sodium.prototype.secretbox = function(_arg) {
       var nonce, plaintext;
       plaintext = _arg.plaintext, nonce = _arg.nonce;
-      return this.lib.c.crypto_secretbox(plaintext, nonce, this.secretKey).slice(16);
+      return this._unpad(this.lib.c.crypto_secretbox(plaintext, nonce, this.secretKey));
     };
 
     Sodium.prototype.decrypt = function(_arg) {
       var ciphertext, nonce, pubkey;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce, pubkey = _arg.pubkey;
-      return this.lib.c.crypto_box_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, pubkey, this.secretKey);
+      return this.lib.c.crypto_box_open(this._pad(ciphertext), nonce, pubkey, this.secretKey);
     };
 
     Sodium.prototype.secretbox_open = function(_arg) {
       var ciphertext, nonce;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce;
-      return this.lib.c.crypto_secretbox_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, this.secretKey);
+      return this.lib.c.crypto_secretbox_open(this._pad(ciphertext), nonce, this.secretKey);
     };
 
     Sodium.prototype.box_beforenm = function(_arg) {
@@ -198,7 +206,7 @@
     Sodium.prototype.box_open_afternm = function(_arg) {
       var ciphertext, nonce, secret;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce, secret = _arg.secret;
-      return this.lib.c.crypto_box_open_afternm(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, secret);
+      return this.lib.c.crypto_box_open_afternm(this._pad(ciphertext), nonce, secret);
     };
 
     return Sodium;

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -189,6 +189,18 @@
       return this.lib.c.crypto_secretbox_open(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, this.secretKey);
     };
 
+    Sodium.prototype.box_beforenm = function(_arg) {
+      var pubkey, seckey;
+      pubkey = _arg.pubkey, seckey = _arg.seckey;
+      return this.lib.c.crypto_box_beforenm(pubkey, seckey);
+    };
+
+    Sodium.prototype.box_open_afternm = function(_arg) {
+      var ciphertext, nonce, secret;
+      ciphertext = _arg.ciphertext, nonce = _arg.nonce, secret = _arg.secret;
+      return this.lib.c.crypto_box_open_afternm(Buffer.concat([Buffer.alloc(16), ciphertext]), nonce, secret);
+    };
+
     return Sodium;
 
   })(Base);
@@ -270,6 +282,18 @@
       var ciphertext, nonce;
       ciphertext = _arg.ciphertext, nonce = _arg.nonce;
       return u2b(this.lib.js.secretbox.open(b2u(ciphertext), nonce, this.secretKey));
+    };
+
+    TweetNaCl.prototype.box_beforenm = function(_arg) {
+      var pubkey, seckey;
+      pubkey = _arg.pubkey, seckey = _arg.seckey;
+      return u2b(this.lib.js.box.before(pubkey, seckey));
+    };
+
+    TweetNaCl.prototype.box_open_afternm = function(_arg) {
+      var ciphertext, nonce, secret;
+      ciphertext = _arg.ciphertext, nonce = _arg.nonce, secret = _arg.secret;
+      return u2b(this.lib.js.box.open.after(b2u(ciphertext), nonce, secret));
     };
 
     return TweetNaCl;


### PR DESCRIPTION
Just more wrappers. Fully tested. Made tests run a bit faster by using a 2MB message instead of 20.